### PR TITLE
STYLE: 포트폴리오 페이지 CSS 수정

### DIFF
--- a/src/components/PortfolioChart.jsx
+++ b/src/components/PortfolioChart.jsx
@@ -41,6 +41,7 @@ function PortfolioChart() {
         justifyContent: 'center',
         alignItems: 'center',
         width: '100%',
+        margin: 0,
       }}
     >
       {data ? (
@@ -48,11 +49,11 @@ function PortfolioChart() {
           series={[
             {
               data,
-              innerRadius: 75,
+              innerRadius: 120,
             },
           ]}
           width={800}
-          height={200}
+          height={300}
         />
       ) : (
         <p>Loading...</p>

--- a/src/components/PortfolioTable.jsx
+++ b/src/components/PortfolioTable.jsx
@@ -27,7 +27,7 @@ const EditableCell = ({
   onSearch,
 }) => {
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', paddingX: 'auto' }}>
       {isEditable ? (
         <TextField
           variant="standard"
@@ -240,9 +240,27 @@ function PortfolioTable() {
 
   return (
     <div>
-      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
-        <TableContainer component={Paper} sx={{ maxWidth: 1000 }}>
-          <Table sx={{ minWidth: 275 }} aria-label="portfolio table">
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          mt: 2,
+          marginTop: '80px',
+        }}
+      >
+        <TableContainer
+          component={Paper}
+          sx={{
+            maxWidth: 1000,
+            border: 'none',
+            boxShadow: 'none',
+            marginBottom: '100px',
+          }}
+        >
+          <Table
+            sx={{ minWidth: 275, border: 'none' }}
+            aria-label="portfolio table"
+          >
             <TableHead>
               <TableRow>
                 <TableCell align="left">기업명</TableCell>
@@ -348,13 +366,21 @@ function PortfolioTable() {
             <IconButton size="small" onClick={handleAddRow}>
               <AddCircleOutlineIcon color="primary" />
             </IconButton>
-            <Button variant="contained" onClick={handleSave} sx={{ ml: 1 }}>
+            <Button
+              variant="contained"
+              onClick={handleSave}
+              sx={{ ml: 1, width: '165px', borderRadius: '10px' }}
+            >
               저장
             </Button>
           </>
         ) : !isEditMode ? (
           // 데이터가 있고 편집 모드가 아닐 때
-          <Button variant="contained" onClick={() => setIsEditMode(true)}>
+          <Button
+            variant="contained"
+            sx={{ width: '165px', borderRadius: '10px' }}
+            onClick={() => setIsEditMode(true)}
+          >
             수정하기
           </Button>
         ) : (
@@ -369,11 +395,15 @@ function PortfolioTable() {
                 setIsEditMode(false);
                 handleCancelEdit();
               }}
-              sx={{ ml: 1 }}
+              sx={{ ml: 1, width: '165px', borderRadius: '10px' }}
             >
               취소
             </Button>
-            <Button variant="contained" onClick={handleSave} sx={{ ml: 1 }}>
+            <Button
+              variant="contained"
+              onClick={handleSave}
+              sx={{ ml: 1, width: '165px', borderRadius: '10px' }}
+            >
               저장
             </Button>
           </>

--- a/src/components/RecommendPortfolio.jsx
+++ b/src/components/RecommendPortfolio.jsx
@@ -62,7 +62,7 @@ function RecommendPortfolio() {
         <Typography>보유 주식에 어울리는 종목을 추천해드려요</Typography>
         <Button
           variant="contained"
-          sx={{ mt: 2 }}
+          sx={{ mt: 2, width: '235px' }}
           onClick={() => navigate('/portfolio-recommend')}
         >
           AI 종목 추천(1일 1회)
@@ -78,7 +78,7 @@ function RecommendPortfolio() {
       <Typography>보유 주식에 어울리는 종목을 추천해드려요</Typography>
       <Button
         variant="contained"
-        sx={{ mt: 2 }}
+        sx={{ mt: 2, width: '235px', borderRadius: '10px' }}
         onClick={() => navigate('/portfolio-recommend')}
       >
         추천 결과 보러가기

--- a/src/pages/KeywordDetails.jsx
+++ b/src/pages/KeywordDetails.jsx
@@ -13,7 +13,12 @@ const KeywordDetails = () => {
   return (
     <div>
       <NavBar />
-      <div style={{ paddingLeft: '200px', paddingRight: '200px' }}>
+      <div
+        style={{
+          paddingLeft: '200px',
+          paddingRight: '200px',
+        }}
+      >
         <Keyword keywordId={keyword_id} />
         <KeywordNews keywordId={keyword_id} />
         <RecommendStockSearchVolume keywordId={keyword_id} />

--- a/src/pages/Portfolio.jsx
+++ b/src/pages/Portfolio.jsx
@@ -2,40 +2,74 @@ import React from 'react';
 import PortfolioTable from '../components/PortfolioTable';
 import RecommendPortfolio from '../components/RecommendPortfolio';
 import PortfolioChart from '../components/PortfolioChart';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
+import NavBar from '../components/NavBar';
+import { Padding } from '@mui/icons-material';
 
 function Portfolio() {
   return (
     <div>
-      <h1>나의 주식 포트폴리오</h1>
-      {/* Chart와 Recommendation을 가로로 배치 */}
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between', // 공간을 균등하게 분배
-          gap: 4, // 컴포넌트 간 간격
-          mb: 30, // 아래 Table과의 간격
-          width: '100%', // 부모 Box의 가로 크기를 100%로 설정
-          maxWidth: 1500, // 최대 너비 제한
-          margin: '0 auto', // 화면 가운데 정렬
-          alignItems: 'center',
+      <NavBar />
+      <div
+        style={{
+          paddingLeft: '200px',
+          paddingRight: '200px',
+          paddingBottom: '200px',
         }}
       >
-        {/* PortfolioChart */}
-        <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
-          <PortfolioChart />
+        <h1
+          style={{
+            marginLeft: '200px',
+            marginRight: 'auto',
+            paddingBottom: '50px',
+          }}
+        >
+          나의 주식 포트폴리오
+        </h1>
+        {/* Chart와 Recommendation을 가로로 배치 */}
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between', // 공간을 균등하게 분배
+            gap: 2, // 컴포넌트 간 간격
+            mb: 30, // 아래 Table과의 간격
+            width: '100%', // 부모 Box의 가로 크기를 100%로 설정
+            maxWidth: 1500, // 최대 너비 제한
+            margin: '0 auto', // 화면 가운데 정렬
+            alignItems: 'center',
+            paddingX: 'auto',
+          }}
+        >
+          {/* PortfolioChart */}
+          <Box
+            sx={{
+              flex: 1,
+              display: 'flex',
+              justifyContent: 'center',
+              maxWidth: '50%',
+            }}
+          >
+            <PortfolioChart />
+          </Box>
+
+          {/* RecommendPortfolio */}
+          <Box
+            sx={{
+              flex: 1,
+              display: 'flex',
+              justifyContent: 'center',
+              maxWidth: '50%',
+            }}
+          >
+            <RecommendPortfolio />
+          </Box>
         </Box>
 
-        {/* RecommendPortfolio */}
-        <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
-          <RecommendPortfolio />
+        {/* Table */}
+        <Box>
+          <PortfolioTable />
         </Box>
-      </Box>
-
-      {/* Table */}
-      <Box>
-        <PortfolioTable />
-      </Box>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
#️⃣연관된 이슈
#24 

📝작업 내용
1. 페이지의 전반적인 여백을 조정하였습니다.
2. porfolioTable의 테두리를 제거하였습니다.
3. 버튼들의 사이즈를 조정하고, border-radius를 수정하였습니다.
4. 포트폴리오 차트의 크기를 수정하고, ai종목추천 recommendportfolio와의 위치를 조정하였습니다. 

스크린샷 (선택)
![localhost_3000_portfolio](https://github.com/user-attachments/assets/3bbef6c2-0ab1-4e27-b846-925986bee9a1)
![스크린샷 2024-12-18 090859](https://github.com/user-attachments/assets/7c0f0a0e-68a3-45c1-860c-91cf3a97b3cc)

💬리뷰 요구사항(선택)
